### PR TITLE
Update build-linux.yml

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -47,7 +47,7 @@ jobs:
         python -m zipfile -e Picocrypt.zip Picocrypt
         cp src/Picocrypt Picocrypt/Picocrypt/usr/bin/picocrypt-gui
         cd Picocrypt
-        dpkg-deb --build --root-owner-group Picocrypt
+        dpkg-deb -Zxz --build --root-owner-group Picocrypt
 
     - name: Prepare to upload artifacts
       run: |


### PR DESCRIPTION
Change the compression method to xz when building the deb package to ensure support for older deb-based distributions.