### PR TITLE
Github Actions with sha256 in release body

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -72,6 +72,11 @@ jobs:
         if-no-files-found: error
         compression-level: 9
 
+    - name: Generate checksums
+      run: |
+        echo "CHECKSUM_PICOCRYPT=$(sha256sum Picocrypt | cut -d ' ' -f1)" >> $GITHUB_ENV
+        echo "CHECKSUM_DEB=$(sha256sum Picocrypt.deb | cut -d ' ' -f1)" >> $GITHUB_ENV
+
     - name: Release
       uses: softprops/action-gh-release@v2
       with:
@@ -80,3 +85,6 @@ jobs:
           Picocrypt.deb
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        body: |
+          **Picocrypt sha256**: ${{ env.CHECKSUM_PICOCRYPT }}
+          **Picocrypt.deb sha256**: ${{ env.CHECKSUM_DEB }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -86,5 +86,6 @@ jobs:
         tag_name: ${{ env.VERSION }}
         make_latest: true
         body: |
-          **Picocrypt sha256**: ${{ env.CHECKSUM_PICOCRYPT }}
-          **Picocrypt.deb sha256**: ${{ env.CHECKSUM_DEB }}
+          **SHA256:**
+          **Picocrypt      ${{ env.CHECKSUM_PICOCRYPT }}
+          **Picocrypt.deb  ${{ env.CHECKSUM_DEB }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -5,10 +5,10 @@ permissions:
 
 on:
   push:
-      paths:
-        - "VERSION"
-      branches:
-        - main
+    paths:
+      - "VERSION"
+    branches:
+      - main
 
 jobs:
   build:
@@ -63,6 +63,11 @@ jobs:
         VERSION=$(cat VERSION)
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
+    - name: Generate checksums
+      run: |
+        HASH=$(shasum -a 256 Picocrypt.dmg | cut -d ' ' -f1)
+        echo "CHECKSUM_PICOCRYPT=$HASH" >> $GITHUB_ENV
+
     - name: Release
       uses: softprops/action-gh-release@v2
       with:
@@ -70,3 +75,5 @@ jobs:
           Picocrypt.dmg
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        body: |
+          **Picocrypt.dmg sha256**: ${{ env.CHECKSUM_PICOCRYPT }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -76,4 +76,4 @@ jobs:
         tag_name: ${{ env.VERSION }}
         make_latest: true
         body: |
-          **Picocrypt.dmg sha256**: ${{ env.CHECKSUM_PICOCRYPT }}
+          **Picocrypt.dmg  ${{ env.CHECKSUM_PICOCRYPT }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -92,4 +92,4 @@ jobs:
         tag_name: ${{ env.VERSION }}
         make_latest: true
         body: |
-          **Picocrypt.exe sha256**: ${{ env.CHECKSUM_PICOCRYPT }}
+          **Picocrypt.exe  ${{ env.CHECKSUM_PICOCRYPT }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,10 +5,10 @@ permissions:
 
 on:
   push:
-      paths:
-        - "VERSION"
-      branches:
-        - main
+    paths:
+      - "VERSION"
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -78,6 +78,12 @@ jobs:
         $version = Get-Content -Path "VERSION"
         echo "VERSION=$version" >> $env:GITHUB_ENV
 
+    - name: Generate checksums
+      shell: pwsh
+      run: |
+        $hash = Get-FileHash "src/Picocrypt.exe" -Algorithm SHA256
+        echo "CHECKSUM_PICOCRYPT=$($hash.Hash)" >> $env:GITHUB_ENV
+
     - name: Release
       uses: softprops/action-gh-release@v2
       with:
@@ -85,3 +91,5 @@ jobs:
           src/Picocrypt.exe
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        body: |
+          **Picocrypt.exe sha256**: ${{ env.CHECKSUM_PICOCRYPT }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ba1a5b53-4a25-4dda-8893-0bb41484979e)
There will be sha256 hashes of all release files (except .zip and .tar.gz sources)