### PR TITLE
UPX for Linux & upgrade UPX for Windows

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -41,6 +41,12 @@ jobs:
         CGO_ENABLED: 1
         GOAMD64: v1
 
+    - name: Compress with upx
+      run: |
+        wget -O upx.tar.xz https://github.com/upx/upx/releases/download/v5.0.2/upx-5.0.2-amd64_linux.tar.xz
+        tar -xf upx.tar.xz
+        upx-5.0.2-amd64_linux/upx --lzma src/Picocrypt
+
     - name: Package as .deb
       run: |
         wget https://github.com/user-attachments/files/16136712/Picocrypt.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         Invoke-WebRequest -OutFile upx.zip https://github.com/user-attachments/files/15894908/upx-4.2.4-win64.zip
         Expand-Archive -DestinationPath upx upx.zip
-        upx/upx-4.2.4-win64/upx.exe --lzma --brute -o src/Picocrypt.exe src/5.exe
+        upx/upx-4.2.4-win64/upx.exe --lzma -o src/Picocrypt.exe src/5.exe
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -60,9 +60,9 @@ jobs:
     - name: Compress with upx
       shell: pwsh
       run: |
-        Invoke-WebRequest -OutFile upx.zip https://github.com/user-attachments/files/15894908/upx-4.2.4-win64.zip
+        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.0.2/upx-5.0.2-win64.zip
         Expand-Archive -DestinationPath upx upx.zip
-        upx/upx-4.2.4-win64/upx.exe --lzma -o src/Picocrypt.exe src/5.exe
+        upx/upx-5.0.2-win64/upx.exe --lzma -o src/Picocrypt.exe src/5.exe
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-test-build-linux.yml
+++ b/.github/workflows/pr-test-build-linux.yml
@@ -38,6 +38,12 @@ jobs:
         CGO_ENABLED: 1
         GOAMD64: v1
 
+    - name: Compress with upx
+      run: |
+        wget -O upx.tar.xz https://github.com/upx/upx/releases/download/v5.0.2/upx-5.0.2-amd64_linux.tar.xz
+        tar -xf upx.tar.xz
+        upx-5.0.2-amd64_linux/upx --lzma src/Picocrypt
+
     - name: Package as .deb
       run: |
         wget https://github.com/user-attachments/files/16136712/Picocrypt.zip

--- a/.github/workflows/pr-test-build-windows.yml
+++ b/.github/workflows/pr-test-build-windows.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         Invoke-WebRequest -OutFile upx.zip https://github.com/user-attachments/files/15894908/upx-4.2.4-win64.zip
         Expand-Archive -DestinationPath upx upx.zip
-        upx/upx-4.2.4-win64/upx.exe --lzma --brute -o src/Picocrypt.exe src/5.exe
+        upx/upx-4.2.4-win64/upx.exe --lzma -o src/Picocrypt.exe src/5.exe
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-test-build-windows.yml
+++ b/.github/workflows/pr-test-build-windows.yml
@@ -57,9 +57,9 @@ jobs:
     - name: Compress with upx
       shell: pwsh
       run: |
-        Invoke-WebRequest -OutFile upx.zip https://github.com/user-attachments/files/15894908/upx-4.2.4-win64.zip
+        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.0.2/upx-5.0.2-win64.zip
         Expand-Archive -DestinationPath upx upx.zip
-        upx/upx-4.2.4-win64/upx.exe --lzma -o src/Picocrypt.exe src/5.exe
+        upx/upx-5.0.2-win64/upx.exe --lzma -o src/Picocrypt.exe src/5.exe
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,7 +4,7 @@ go 1.24.2
 
 require (
 	github.com/Picocrypt/dialog v0.0.0-20250412233924-78f7b909315b
-	github.com/Picocrypt/giu v0.0.0-20250412235908-fe90a482e6f2
+	github.com/Picocrypt/giu v0.0.0-20250801020750-ec85cd24c933
 	github.com/Picocrypt/imgui-go v0.0.0-20250412235405-d86b230f5fbb
 	github.com/Picocrypt/infectious v0.0.0-20250412183341-9f88c6307b39
 	github.com/Picocrypt/serpent v0.0.0-20240830233833-9ad6ab254fd7

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,7 +1,7 @@
 github.com/Picocrypt/dialog v0.0.0-20250412233924-78f7b909315b h1:k5YGEx61N6K8l2l6AQ1u5W2aR+47sVZWFyqXS/f5lIA=
 github.com/Picocrypt/dialog v0.0.0-20250412233924-78f7b909315b/go.mod h1:OyaP0Tz19qL3RAGq5Ntues+WVrIbHh5MrfqoA/qhqeg=
-github.com/Picocrypt/giu v0.0.0-20250412235908-fe90a482e6f2 h1:SPR2efZTpZJON/2mNifLi68Gl9Epxh/1nXb3kGGHCcg=
-github.com/Picocrypt/giu v0.0.0-20250412235908-fe90a482e6f2/go.mod h1:jd6AonK0ZI02R7GqLWb4gWJz/A2ClF36Y4fFMR8Lzbk=
+github.com/Picocrypt/giu v0.0.0-20250801020750-ec85cd24c933 h1:4K9zEOVimmirylJ2ZFSNdJeAjLSCrkgWuCtPDlWw+wo=
+github.com/Picocrypt/giu v0.0.0-20250801020750-ec85cd24c933/go.mod h1:jd6AonK0ZI02R7GqLWb4gWJz/A2ClF36Y4fFMR8Lzbk=
 github.com/Picocrypt/gl v0.0.0-20250412234430-767b58dbf936 h1:6MChjQ4AZC2ISBjbgZU/z6tSUxYP50NkRvAu0T2kjlY=
 github.com/Picocrypt/gl v0.0.0-20250412234430-767b58dbf936/go.mod h1:pMdf3io/y3I+zYZ6/xFb3MlI2AgL38enDDIKuR0n2qA=
 github.com/Picocrypt/glfw/v3.3/glfw v0.0.0-20250412234750-7b96bfdb8dd8 h1:i8wXJhSYIJTXb6sqBS6JZW7QosI9u8Ysy1BHZCTuZEc=


### PR DESCRIPTION
Sometimes it seems a little unfair that the Picocrypt build on Windows is compressed using UPX, but the build on Linux is not... I decided to fix this and also update UPX for Windows to the latest version.